### PR TITLE
refactor(test): port testing doubles to an independent module

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "tasks": {
-    "cache": "deno cache ./lib/*/*.ts --lock",
+    "cache": "deno cache ./lib/*/*.ts --reload --lock",
     "lock": "deno task -q cache --lock-write && git add deno.lock",
     "check": "deno check ./*.ts ./lib/*/*.ts",
     "test": "deno test -A --no-check",

--- a/deno.lock
+++ b/deno.lock
@@ -250,6 +250,6 @@
     "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
     "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
     "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/fmt/colors.ts": "c51c4642678eb690dcf5ffee5918b675bf01a33fba82acf303701ae1a4f8c8d9",
-    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/testing/mock.ts": "af6fd7bafb04dc5333e9e6c571f5413449fa96f8fd8db1fdeb46dc45dd0ba7ba"
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/testing/mock.ts": "abd5044f9f47df0987e4b6c06fa617a5ba6d261c006b3ff8a2aa21f9d1802196"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -250,6 +250,6 @@
     "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
     "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
     "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/fmt/colors.ts": "c51c4642678eb690dcf5ffee5918b675bf01a33fba82acf303701ae1a4f8c8d9",
-    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/testing/mock.ts": "01ef776b3adc53cc04f79d85d2123a2156a49a7a0a955fdcce05ac1e2fae5629"
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/testing/mock.ts": "af6fd7bafb04dc5333e9e6c571f5413449fa96f8fd8db1fdeb46dc45dd0ba7ba"
   }
 }

--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,8 @@
 {
   "version": "3",
+  "redirects": {
+    "https://pax.deno.dev/hasundue/deno_std@feat-constructor-spy/testing/mock.ts": "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/testing/mock.ts"
+  },
   "remote": {
     "https://deno.land/std@0.186.0/async/deferred.ts": "42790112f36a75a57db4a96d33974a936deb7b04d25c6084a9fa8a49f135def8",
     "https://deno.land/std@0.196.0/_util/os.ts": "d932f56d41e4f6a6093d56044e29ce637f8dcc43c5a90af43504a889cf1775e3",
@@ -87,7 +90,6 @@
     "https://deno.land/std@0.204.0/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
     "https://deno.land/std@0.204.0/assert/assert_not_equals.ts": "9f1acab95bd1f5fc9a1b17b8027d894509a745d91bac1718fdab51dc76831754",
     "https://deno.land/std@0.204.0/assert/assert_object_match.ts": "d8fc2867cfd92eeacf9cea621e10336b666de1874a6767b5ec48988838370b54",
-    "https://deno.land/std@0.204.0/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
     "https://deno.land/std@0.204.0/assert/assert_throws.ts": "63784e951475cb7bdfd59878cd25a0931e18f6dc32a6077c454b2cd94f4f4bcd",
     "https://deno.land/std@0.204.0/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
     "https://deno.land/std@0.204.0/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
@@ -132,7 +134,6 @@
     "https://deno.land/std@0.204.0/path/windows/to_file_url.ts": "8e9ea9e1ff364aa06fa72999204229952d0a279dbb876b7b838b2b2fea55cce3",
     "https://deno.land/std@0.204.0/testing/_test_suite.ts": "30f018feeb3835f12ab198d8a518f9089b1bcb2e8c838a8b615ab10d5005465c",
     "https://deno.land/std@0.204.0/testing/bdd.ts": "3f446df5ef8e856a869e8eec54c8482590415741ff0b6358a00c43486cc15769",
-    "https://deno.land/std@0.204.0/testing/mock.ts": "6576b4aa55ee20b1990d656a78fff83599e190948c00e9f25a7f3ac5e9d6492d",
     "https://deno.land/x/async@v2.0.2/mutex.ts": "312dcad7468c82f84fd018be157df451361ed19bdc12fd59af8d12b2e6c3ae28",
     "https://deno.land/x/cliffy@v1.0.0-rc.3/_utils/distance.ts": "02af166952c7c358ac83beae397aa2fbca4ad630aecfcd38d92edb1ea429f004",
     "https://deno.land/x/cliffy@v1.0.0-rc.3/ansi/ansi_escapes.ts": "193b3c3a4e520274bd8322ca4cab1c3ce38070bed1898cb2ade12a585dddd7c9",
@@ -239,6 +240,16 @@
     "https://deno.land/x/unknownutil@v3.10.0/util.ts": "5c9b52ef699e569ccec9d4c33148545bf5328c6a5e2f6f56f651ce6bdd44eb1e",
     "https://deno.land/x/wasmbuild@0.15.1/cache.ts": "9d01b5cb24e7f2a942bbd8d14b093751fa690a6cde8e21709ddc97667e6669ed",
     "https://deno.land/x/wasmbuild@0.15.1/loader.ts": "8c2fc10e21678e42f84c5135d8ab6ab7dc92424c3f05d2354896a29ccfd02a63",
-    "https://deno.land/x/which@0.3.0/mod.ts": "3e10d07953c14e4ddc809742a3447cef14202cdfe9be6678a1dfc8769c4487e6"
+    "https://deno.land/x/which@0.3.0/mod.ts": "3e10d07953c14e4ddc809742a3447cef14202cdfe9be6678a1dfc8769c4487e6",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/_constants.ts": "8a9da298c26750b28b326b297316cdde860bc237533b07e1337c021379e6b2a9",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/_diff.ts": "58e1461cc61d8eb1eacbf2a010932bf6a05b79344b02ca38095f9b805795dc48",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/_format.ts": "a69126e8a469009adf4cf2a50af889aca364c349797e63174884a52ff75cf4c7",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/assert_equals.ts": "d8ec8a22447fbaf2fc9d7c3ed2e66790fdb74beae3e482855d75782218d68227",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/assert_is_error.ts": "c21113094a51a296ffaf036767d616a78a2ae5f9f7bbd464cd0197476498b94b",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/assert_rejects.ts": "45c59724de2701e3b1f67c391d6c71c392363635aad3f68a1b3408f9efca0057",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/assertion_error.ts": "4d0bde9b374dfbcbe8ac23f54f567b77024fb67dbb1906a852d67fe050d42f56",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/assert/equal.ts": "9f1a46d5993966d2596c44e5858eec821859b45f783a5ee2f7a695dfc12d8ece",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/fmt/colors.ts": "c51c4642678eb690dcf5ffee5918b675bf01a33fba82acf303701ae1a4f8c8d9",
+    "https://raw.githubusercontent.com/hasundue/deno_std/feat-constructor-spy/testing/mock.ts": "01ef776b3adc53cc04f79d85d2123a2156a49a7a0a955fdcce05ac1e2fae5629"
   }
 }

--- a/lib/git_test.ts
+++ b/lib/git_test.ts
@@ -1,6 +1,5 @@
 import {
   afterAll,
-  assertSpyCall,
   assertSpyCalls,
   beforeAll,
   beforeEach,
@@ -13,7 +12,7 @@ import {
 import { URI } from "./uri.ts";
 import { DependencyUpdate } from "./update.ts";
 import { commitAll } from "./git.ts";
-import { createCommandStub } from "./testing.ts";
+import { createCommandStub, assertSomeSpyCall } from "./testing.ts";
 
 const readTextFileOriginal = Deno.readTextFile;
 
@@ -79,13 +78,13 @@ describe("commitAll()", () => {
   it("no grouping", async () => {
     await commitAll(updates);
     // TODO: Can't test this because of the order of targets is not guaranteed.
-    // assertSpyCall(CommandStub, 0, {
+    // assertSomeSpyCall(CommandStub, {
     //   args: [
     //     "git",
     //     { args: ["add", "src/fixtures/mod.ts", "src/fixtures/lib.ts"] },
     //   ],
     // });
-    assertSpyCall(CommandStub, 1, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         { args: ["commit", "-m", "build(deps): update dependencies"] },
@@ -99,25 +98,25 @@ describe("commitAll()", () => {
       groupBy: (update) => update.name,
       composeCommitMessage: ({ group }) => `build(deps): update ${group}`,
     });
-    assertSpyCall(CommandStub, 0, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         { args: ["add", normalizePath("test/fixtures/direct-import/mod.ts")] },
       ],
     });
-    assertSpyCall(CommandStub, 1, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         { args: ["commit", "-m", "build(deps): update node-emoji"] },
       ],
     });
-    assertSpyCall(CommandStub, 2, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         { args: ["add", normalizePath("test/fixtures/direct-import/mod.ts")] },
       ],
     });
-    assertSpyCall(CommandStub, 3, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         {
@@ -126,7 +125,7 @@ describe("commitAll()", () => {
       ],
     });
     // TODO: Can't test this because of the order of targets is not guaranteed.
-    // assertSpyCall(CommandStub, 4, {
+    // assertSomeSpyCall(CommandStub, {
     //   args: [
     //     "git",
     //     {
@@ -138,7 +137,7 @@ describe("commitAll()", () => {
     //     },
     //   ],
     // });
-    assertSpyCall(CommandStub, 5, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         { args: ["commit", "-m", "build(deps): update deno.land/std"] },
@@ -152,13 +151,13 @@ describe("commitAll()", () => {
       groupBy: (update) => URI.relative(update.referrer),
       composeCommitMessage: ({ group }) => `build(deps): update ${group}`,
     });
-    assertSpyCall(CommandStub, 0, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         { args: ["add", normalizePath("test/fixtures/direct-import/mod.ts")] },
       ],
     });
-    assertSpyCall(CommandStub, 1, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         {
@@ -172,13 +171,13 @@ describe("commitAll()", () => {
         },
       ],
     });
-    assertSpyCall(CommandStub, 2, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         { args: ["add", normalizePath("test/fixtures/direct-import/lib.ts")] },
       ],
     });
-    assertSpyCall(CommandStub, 3, {
+    assertSomeSpyCall(CommandStub, {
       args: [
         "git",
         {

--- a/lib/std/assert.ts
+++ b/lib/std/assert.ts
@@ -4,3 +4,4 @@ export { assertExists } from "https://deno.land/std@0.204.0/assert/assert_exists
 export { assertNotEquals } from "https://deno.land/std@0.204.0/assert/assert_not_equals.ts";
 export { assertObjectMatch } from "https://deno.land/std@0.204.0/assert/assert_object_match.ts";
 export { assertThrows } from "https://deno.land/std@0.204.0/assert/assert_throws.ts";
+export { AssertionError } from "https://deno.land/std@0.204.0/assert/assertion_error.ts";

--- a/lib/std/testing.ts
+++ b/lib/std/testing.ts
@@ -10,7 +10,9 @@ export {
   assertSpyCall,
   assertSpyCalls,
   type ConstructorSpy,
+  type Spy,
   spy,
   type Stub,
   stub,
+  type ExpectedSpyCall,
 } from "https://pax.deno.dev/hasundue/deno_std@feat-constructor-spy/testing/mock.ts";

--- a/lib/std/testing.ts
+++ b/lib/std/testing.ts
@@ -6,4 +6,11 @@ export {
   describe,
   it,
 } from "https://deno.land/std@0.204.0/testing/bdd.ts";
-export { type Stub, stub } from "https://deno.land/std@0.204.0/testing/mock.ts";
+export {
+  assertSpyCall,
+  assertSpyCalls,
+  type ConstructorSpy,
+  spy,
+  type Stub,
+  stub,
+} from "https://pax.deno.dev/hasundue/deno_std@feat-constructor-spy/testing/mock.ts";

--- a/lib/std/testing.ts
+++ b/lib/std/testing.ts
@@ -8,11 +8,12 @@ export {
 } from "https://deno.land/std@0.204.0/testing/bdd.ts";
 export {
   assertSpyCall,
+  assertSpyCallArg,
   assertSpyCalls,
   type ConstructorSpy,
+  type ExpectedSpyCall,
   type Spy,
   spy,
   type Stub,
   stub,
-  type ExpectedSpyCall,
 } from "https://pax.deno.dev/hasundue/deno_std@feat-constructor-spy/testing/mock.ts";

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,0 +1,26 @@
+import { spy, ConstructorSpy } from "./std/testing.ts";
+
+export function createCommandStub(): ConstructorSpy {
+  const Spy = spy(Deno.Command);
+  return class extends Spy {
+    #output: Deno.CommandOutput = {
+      code: 0,
+      stdout: new Uint8Array(),
+      stderr: new Uint8Array(),
+      success: true,
+      signal: null,
+    };
+    outputSync() {
+      return this.#output;
+    }
+    output() {
+      return Promise.resolve(this.#output);
+    }
+    spawn() {
+      return new Deno.ChildProcess();
+    }
+    static clear() {
+      this.calls = [];
+    }
+  }
+}

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,8 +1,15 @@
-import { spy, ConstructorSpy } from "./std/testing.ts";
+import {
+  assertSpyCall,
+  ConstructorSpy,
+  ExpectedSpyCall,
+  Spy,
+  spy,
+} from "./std/testing.ts";
+import { AssertionError } from "./std/assert.ts";
 
 export function createCommandStub(): ConstructorSpy {
-  const Spy = spy(Deno.Command);
-  return class extends Spy {
+  const CommandSpy = spy(Deno.Command);
+  return class extends CommandSpy {
     #output: Deno.CommandOutput = {
       code: 0,
       stdout: new Uint8Array(),
@@ -22,5 +29,27 @@ export function createCommandStub(): ConstructorSpy {
     static clear() {
       this.calls = [];
     }
+  };
+}
+
+/** Asserts that a spy is called as expected at any index. */
+export function assertSomeSpyCall<
+  Self,
+  Args extends unknown[],
+  Return,
+>(
+  spy: Spy<Self, Args, Return>,
+  expected: ExpectedSpyCall<Self, Args, Return>,
+) {
+  const some = spy.calls.some((_, index) => {
+    try {
+      assertSpyCall(spy, index, expected);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  if (!some) {
+    throw new AssertionError("spy call does not exist");
   }
 }

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -1,9 +1,12 @@
 import {
   assertSpyCall,
+  assertSpyCallArg,
   ConstructorSpy,
   ExpectedSpyCall,
   Spy,
   spy,
+  Stub,
+  stub,
 } from "./std/testing.ts";
 import { AssertionError } from "./std/assert.ts";
 
@@ -32,6 +35,41 @@ export function createCommandStub(): ConstructorSpy {
   };
 }
 
+export class FileSystemFake extends Map<string | URL, Uint8Array> {}
+
+export function createReadTextFileStub(
+  fs: FileSystemFake,
+  options?: {
+    readThrough?: boolean;
+  },
+): Stub {
+  const decoder = new TextDecoder();
+  return stub(
+    Deno,
+    "readTextFile",
+    async (path) => {
+      const data = fs.get(path) ?? options?.readThrough
+        ? await Deno.readFile(path)
+        : _throw(new Deno.errors.NotFound(`File not found: ${path}`));
+      return decoder.decode(data);
+    },
+  );
+}
+
+export function createWriteTextFileStub(
+  fs: FileSystemFake,
+): Stub {
+  const encoder = new TextEncoder();
+  return stub(
+    Deno,
+    "writeTextFile",
+    // deno-lint-ignore require-await
+    async (path, data) => {
+      fs.set(path, encoder.encode(data.toString()));
+    },
+  );
+}
+
 /** Asserts that a spy is called as expected at any index. */
 export function assertSomeSpyCall<
   Self,
@@ -50,6 +88,34 @@ export function assertSomeSpyCall<
     }
   });
   if (!some) {
-    throw new AssertionError("spy call does not exist");
+    throw new AssertionError("Expected spy call does not exist");
   }
+}
+
+export function assertSomeSpyCallArg<
+  Self,
+  Args extends unknown[],
+  Return,
+  ExpectedArg,
+>(
+  spy: Spy<Self, Args, Return>,
+  argIndex: number,
+  expected: ExpectedArg,
+) {
+  const some = spy.calls.some((_, index) => {
+    try {
+      assertSpyCallArg(spy, index, argIndex, expected);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+  if (!some) {
+    throw new AssertionError("Expected spy call does not exist");
+  }
+}
+
+/** Utility function to throw an error. */
+function _throw(error: Error): never {
+  throw error;
 }

--- a/lib/testing_test.ts
+++ b/lib/testing_test.ts
@@ -1,0 +1,19 @@
+import { assertObjectMatch } from "./std/assert.ts";
+import { assertSpyCall, assertSpyCalls } from "./std/testing.ts";
+import { createCommandStub } from "./testing.ts";
+
+Deno.test("CommandStub", async () => {
+  const CommandStub = createCommandStub();
+  const output = await new CommandStub("echo").output();
+  assertObjectMatch(output, {
+    code: 0,
+    stdout: new Uint8Array(),
+    stderr: new Uint8Array(),
+    success: true,
+    signal: null,
+  });
+  assertSpyCall(CommandStub, 0, {
+    args: ["echo"],
+  });
+  assertSpyCalls(CommandStub, 1);
+});


### PR DESCRIPTION
- build(deps): update dependencies
- test: add `createCommandStub`
- test: add `assertSomeSpyCall()`
- test: add stubs for filesystem
