### PR TITLE
 fix: unexpected subpaths in import maps by updates

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -3,7 +3,7 @@
     "cache": "deno cache ./lib/*/*.ts --lock",
     "lock": "deno task -q cache --lock-write && git add deno.lock",
     "check": "deno check ./*.ts ./lib/*.ts ./test/integration/*.ts",
-    "test": "NO_COLOR=1 deno test -A --no-check ./lib/*.ts",
+    "test": "NO_COLOR=1 deno test -A --no-check ./lib",
     "all": "deno fmt && deno lint && deno task -q check && deno task lock && deno task -q test",
     "integration": "NO_COLOR=1 deno test --no-lock -A ./test/integration/*.ts",
     "run": "deno run --allow-env --allow-read --allow-net --allow-write=. --allow-run=git,deno cli.ts",

--- a/lib/file.ts
+++ b/lib/file.ts
@@ -1,4 +1,3 @@
-import { assertExists } from "./std/assert.ts";
 import { parse as parseJsonc } from "./std/jsonc.ts";
 import { detectEOL } from "./std/fs.ts";
 import { toUrl } from "./dependency.ts";
@@ -127,11 +126,7 @@ async function writeToImportMap(
   const content = await Deno.readTextFile(update.path);
   const json = parseJsonc(content) as unknown as ImportMapJson;
   for (const dependency of update.dependencies) {
-    assertExists(dependency.map);
-    json.imports[dependency.map.key!] = dependency.map.resolved.replace(
-      toUrl(dependency.from),
-      toUrl(dependency.to),
-    );
+    json.imports[dependency.map!.key!] = toUrl(dependency.to);
   }
   await Deno.writeTextFile(update.path, JSON.stringify(json, null, 2));
 }

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -8,7 +8,11 @@ import {
   type ModuleJson,
 } from "./x/deno_graph.ts";
 import { findFileUp, toPath, toUrl } from "./path.ts";
-import { ImportMap, tryReadFromJson } from "./import_map.ts";
+import {
+  ImportMap,
+  ImportMapResolveResult,
+  tryReadFromJson,
+} from "./import_map.ts";
 import {
   type Dependency,
   parse,
@@ -43,11 +47,7 @@ export interface DependencyUpdate {
     /** The full path to the import map used to resolve the dependency.
      * @example "/path/to/import_map.json" */
     source: string;
-    /** The string in the dependency specifier being replaced */
-    key?: string;
-    /** The fully resolved specifier (URL) of the dependency. */
-    resolved: string;
-  };
+  } & ImportMapResolveResult;
 }
 
 class DenoGraph {
@@ -233,8 +233,7 @@ async function create(
     map: mapped
       ? {
         source: options!.importMap!.path,
-        key: mapped.key,
-        resolved: mapped.resolved,
+        ...mapped,
       }
       : undefined,
   };

--- a/test/snapshots/file_test.ts.snap
+++ b/test/snapshots/file_test.ts.snap
@@ -352,7 +352,7 @@ snapshot[`write - import_map/mod.ts 1`] = `
 [
   '{
   "imports": {
-    "std/": "https://deno.land/std@123.456.789/assert.ts",
+    "std/": "https://deno.land/std@123.456.789/",
     "deno_graph": "https://deno.land/x/deno_graph@123.456.789/mod.ts",
     "node-emoji": "npm:node-emoji@123.456.789",
     "/": "./"


### PR DESCRIPTION
- **chore(tasks): shorten `test` and `integration`**
- **refactor(lib/update): simplify `map` property**
- **fix: unexpected subpaths in import maps by updates**
