### PR TITLE
fix: preserve trailing slashes in import URLs

### DIFF
--- a/lib/dependency.ts
+++ b/lib/dependency.ts
@@ -268,7 +268,7 @@ async function _resolveLatestVersion(
         ...latest,
         // Preserve the original path if it is the root, which is unlikely to be
         // included in the redirected URL.
-        // path: dependency.path === "/" ? "/" : latest.path,
+        path: dependency.path === "/" ? "/" : latest.path,
       };
     }
   }

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -154,7 +154,9 @@ function parseDenoLandUrl(url: URL) {
   return {
     name: std ? "deno.land/std" : `deno.land/x/${name}`,
     version,
-    path,
+    // Remove a trailing slash if it exists to imitate the behavior of typical
+    // Web servers.
+    path: path.replace(/\/$/, ""),
   };
 }
 

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -256,7 +256,7 @@ async function _createDependencyUpdate(
     );
   }
   return {
-    from: dependency,
+    from: normalizeWithUpdated(dependency, latest),
     to: latest,
     code: {
       // We prefer to put the original specifier here.
@@ -297,7 +297,7 @@ async function _collectFromImportMap(
           return;
         }
         updates.push({
-          from: dependency,
+          from: normalizeWithUpdated(dependency, latest),
           to: latest,
           code: {
             specifier: value,
@@ -315,6 +315,19 @@ async function _collectFromImportMap(
     ),
   );
   return updates;
+}
+
+function normalizeWithUpdated(
+  dependency: Dependency,
+  updated: UpdatedDependency,
+): Dependency {
+  if (dependency.version) {
+    return dependency;
+  }
+  return {
+    ...updated,
+    version: undefined,
+  };
 }
 
 export type VersionChange = {

--- a/lib/update_test.ts
+++ b/lib/update_test.ts
@@ -13,6 +13,7 @@ async function test(
 ) {
   try {
     const updates = await collect(new URL(path, import.meta.url), {
+      cache: false,
       cwd: new URL(dirname(path), import.meta.url),
     });
     Deno.test(

--- a/test/snapshots/file_test.ts.snap
+++ b/test/snapshots/file_test.ts.snap
@@ -1159,9 +1159,10 @@ snapshot[`associateByFile - unversioned.ts 1`] = `
           specifier: "https://deno.land/std/assert/assert.ts",
         },
         from: {
-          name: "deno.land/std/assert/assert.ts",
-          path: "",
+          name: "deno.land/std",
+          path: "/assert/assert.ts",
           protocol: "https:",
+          version: undefined,
         },
         map: undefined,
         to: {

--- a/test/snapshots/update_test.ts.snap
+++ b/test/snapshots/update_test.ts.snap
@@ -865,9 +865,10 @@ snapshot[`collect - unversioned.ts 1`] = `
     specifier: "https://deno.land/std/assert/assert.ts",
   },
   from: {
-    name: "deno.land/std/assert/assert.ts",
-    path: "",
+    name: "deno.land/std",
+    path: "/assert/assert.ts",
     protocol: "https:",
+    version: undefined,
   },
   to: {
     name: "deno.land/std",


### PR DESCRIPTION
- **refactor(lib): normalize unversioned dependencies**
- **refactor(lib): an option to enable/disable cache**
- **test(lib): remove a trailing slash from redirect**
- **fix: preserve trailing slashes in import URLs**
