### PR TITLE
fix: accept a lock file without `dependencies`

### DIFF
--- a/lib/lockfile.ts
+++ b/lib/lockfile.ts
@@ -25,7 +25,7 @@ const isLockFileJson = is.ObjectOf({
   })),
   remote: is.OptionalOf(is.RecordOf(is.String, is.String)),
   workspace: is.OptionalOf(is.ObjectOf({
-    dependencies: is.ArrayOf(is.String),
+    dependencies: is.OptionalOf(is.ArrayOf(is.String)),
   })),
 });
 

--- a/test/snapshots/cli.ts.snap
+++ b/test/snapshots/cli.ts.snap
@@ -65,7 +65,7 @@ Options:
 snapshot[`cli - "molt --help" 2`] = `""`;
 
 snapshot[`cli - "molt --version" 1`] = `
-"0.16.3
+"0.17.0
 "
 `;
 


### PR DESCRIPTION
- **chore(cli): print full error logs**
- **fix: error on lockfile without `dependencies`**
