### PR TITLE
fix: add EOL at the end of updated lock files

### DIFF
--- a/lib/file.ts
+++ b/lib/file.ts
@@ -146,7 +146,8 @@ async function writeToImportMap(
 async function writeToLockfile(
   update: FileUpdate<"lockfile">,
 ) {
-  const original = await parseLockFileJson(update.path);
+  const content = await Deno.readTextFile(update.path);
+  const original = parseLockFileJson(content);
 
   for await (const dependency of update.dependencies) {
     const specifier = dependency.code.specifier;
@@ -192,7 +193,10 @@ async function writeToLockfile(
       );
     }
   }
-  await Deno.writeTextFile(update.path, JSON.stringify(original, replacer, 2));
+  await Deno.writeTextFile(
+    update.path,
+    JSON.stringify(original, replacer, 2) + (detectEOL(content) ?? EOL),
+  );
 }
 
 function replacer(

--- a/lib/file_test.ts
+++ b/lib/file_test.ts
@@ -5,7 +5,7 @@ import {
   ReadTextFileStub,
   WriteTextFileStub,
 } from "./testing.ts";
-import { assertInstanceOf } from "./std/assert.ts";
+import { assert, assertInstanceOf } from "./std/assert.ts";
 import { assertSnapshot } from "./testing.ts";
 import { collect, CollectResult } from "./update.ts";
 import { associateByFile, type FileUpdate, writeFileUpdate } from "./file.ts";
@@ -86,6 +86,9 @@ function test(path: string, name = toName(path)) {
       if (result) {
         await writeFileUpdate(updates);
         await assertFileSystemSnapshot(t, fs);
+        for await (const content of fs.values()) {
+          assert(content.endsWith("\n"), "should end with a newline");
+        }
       }
     });
   });

--- a/lib/lockfile.ts
+++ b/lib/lockfile.ts
@@ -68,16 +68,13 @@ export interface LockPart {
  * @param specifier - The URL or path to the lockfile.
  * @returns The parsed JSON object of the lockfile.
  */
-export async function parseLockFileJson(
-  specifier: URL | string,
-): Promise<LockFileJson> {
+export function parseLockFileJson(
+  content: string,
+): LockFileJson {
   try {
-    return ensure(
-      JSON.parse(await Deno.readTextFile(specifier)),
-      isLockFileJson,
-    );
+    return ensure(JSON.parse(content), isLockFileJson);
   } catch (cause) {
-    throw new Error(`Failed to parse lockfile: ${specifier}`, { cause });
+    throw new Error(`Failed to parse lockfile`, { cause });
   }
 }
 
@@ -87,12 +84,12 @@ export async function parseLockFileJson(
  * @param specifier - The URL or path to the lockfile.
  * @returns The parsed `LockFile` object.
  */
-export async function parseLockFile(
+export async function readLockFile(
   specifier: URL | string,
 ): Promise<LockFile> {
   return {
     path: toPath(specifier),
-    data: await parseLockFileJson(specifier),
+    data: parseLockFileJson(await Deno.readTextFile(specifier)),
   };
 }
 
@@ -149,7 +146,7 @@ export async function createLockPart(
   }
   return {
     specifier: dependency,
-    data: await parseLockFileJson(lock.path),
+    data: parseLockFileJson(await Deno.readTextFile(lock.path)),
   };
 }
 

--- a/lib/lockfile_test.ts
+++ b/lib/lockfile_test.ts
@@ -2,15 +2,17 @@ import {
   collectUpdateFromLockFile,
   createLockPart,
   createLockPartForEach,
-  parseLockFile,
   parseLockFileJson,
+  readLockFile,
 } from "./lockfile.ts";
 import { assertEquals, assertObjectMatch } from "./std/assert.ts";
 
 Deno.test("parseLockFileJson", async () =>
   assertObjectMatch(
-    await parseLockFileJson(
-      new URL("../test/data/lockfile/deno.updated.lock", import.meta.url),
+    parseLockFileJson(
+      await Deno.readTextFile(
+        new URL("../test/data/lockfile/deno.updated.lock", import.meta.url),
+      ),
     ),
     {
       version: "3",
@@ -55,7 +57,7 @@ Deno.test("createLockPart - npm:hono", async () => {
 
 Deno.test("createLockPartForEach", async () => {
   const updated = await createLockPartForEach(
-    await parseLockFile(
+    await readLockFile(
       new URL("../test/data/lockfile/deno.lock", import.meta.url),
     ),
   );
@@ -95,7 +97,7 @@ Deno.test("createLockPartForEach", async () => {
 
 Deno.test("createLockPartForEach - no updates", async () => {
   const updated = await createLockPartForEach(
-    await parseLockFile(
+    await readLockFile(
       new URL("../test/data/lockfile/deno.lock", import.meta.url),
     ),
     false,
@@ -143,7 +145,7 @@ Deno.test("createLockPartForEach - no updates", async () => {
 
 Deno.test("collectUpdateFromLockFile", async () => {
   const updates = await collectUpdateFromLockFile(
-    await parseLockFile(
+    await readLockFile(
       new URL("../test/data/lockfile/deno.lock", import.meta.url),
     ),
   );
@@ -190,7 +192,7 @@ Deno.test("collectUpdateFromLockFile", async () => {
 
 Deno.test("collectUpdateFromLockFile - with a patch", async () => {
   const updates = await collectUpdateFromLockFile(
-    await parseLockFile(
+    await readLockFile(
       new URL("../test/data/lockfile/deno.lock", import.meta.url),
     ),
     await createLockPart("npm:hono@^3"),

--- a/lib/std/assert.ts
+++ b/lib/std/assert.ts
@@ -1,3 +1,4 @@
+export { assert } from "https://deno.land/std@0.219.1/assert/assert.ts";
 export { assertArrayIncludes } from "https://deno.land/std@0.219.1/assert/assert_array_includes.ts";
 export { assertEquals } from "https://deno.land/std@0.219.1/assert/assert_equals.ts";
 export { assertExists } from "https://deno.land/std@0.219.1/assert/assert_exists.ts";

--- a/lib/testing.ts
+++ b/lib/testing.ts
@@ -145,11 +145,6 @@ export const LatestVersionStub = {
           return new Response(
             JSON.stringify({
               versions: {
-                "1.0.0": {},
-                "1.0.1": {},
-                "1.0.2": { yanked: true },
-                "1.1.0": {},
-                "1.2.0": { yanked: true },
                 [latest]: {},
               },
             }),
@@ -206,6 +201,7 @@ export function enableTestMode() {
     "deno_graph": "0.69.7",
     "node-emoji": "2.1.3",
     "@luca/flag": "1.0.1",
+    "@std/": "0.218.2",
   });
   const fs = new FileSystemFake();
   ReadTextFileStub.create(fs, { readThrough: true });

--- a/lib/update.ts
+++ b/lib/update.ts
@@ -24,7 +24,7 @@ import {
   createLockPart,
   LockFile,
   LockPart,
-  parseLockFile,
+  readLockFile,
 } from "./lockfile.ts";
 
 export type SourceType = "import_map" | "module" | "lockfile";
@@ -186,7 +186,7 @@ export async function collect(
         ? await maybeFile(new URL("deno.lock", toUrl(importMapPath)))
         : undefined))
     : undefined;
-  const lockFile = lockFilePath ? await parseLockFile(lockFilePath) : undefined;
+  const lockFile = lockFilePath ? await readLockFile(lockFilePath) : undefined;
 
   const urls = [from].flat().map((path) => toUrl(path));
   const [jsons, esms] = partition(urls, isJsonPath);

--- a/test/snapshots/cli.ts.snap
+++ b/test/snapshots/cli.ts.snap
@@ -89,7 +89,7 @@ snapshot[`cli - "molt import.ts" 2`] = `
 `;
 
 snapshot[`cli - "molt jsr.ts" 1`] = `
-"📦 @std/assert 0.210.0 => 0.219.1
+"📦 @std/assert 0.210.0 => 0.218.2
 "
 `;
 
@@ -99,7 +99,7 @@ snapshot[`cli - "molt jsr.ts" 2`] = `
 `;
 
 snapshot[`cli - import_map - "molt mod.ts" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 📦 deno.land/x/deno_graph 0.50.0 => 0.69.7
 📦 node-emoji 2.0.0 => 2.1.3
@@ -112,7 +112,7 @@ snapshot[`cli - import_map - "molt mod.ts" 2`] = `
 `;
 
 snapshot[`cli - import_map - "molt mod.ts --import-map deno.json" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 📦 deno.land/x/deno_graph 0.50.0 => 0.69.7
 📦 node-emoji 2.0.0 => 2.1.3
@@ -125,7 +125,7 @@ snapshot[`cli - import_map - "molt mod.ts --import-map deno.json" 2`] = `
 `;
 
 snapshot[`cli - "molt multiple_imports.ts --ignore node-emoji" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 📦 deno.land/x/deno_graph 0.50.0 => 0.69.7
 "
@@ -137,7 +137,7 @@ snapshot[`cli - "molt multiple_imports.ts --ignore node-emoji" 2`] = `
 `;
 
 snapshot[`cli - "molt multiple_imports.ts --ignore=deno_graph,node-emoji" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 "
 `;
@@ -367,7 +367,7 @@ Checked 64 files
 `;
 
 snapshot[`cli - import_map - "molt deno.json" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 📦 deno.land/x/deno_graph 0.50.0 => 0.69.7
 📦 node-emoji 2.0.0 => 2.1.3
@@ -380,7 +380,7 @@ snapshot[`cli - import_map - "molt deno.json" 2`] = `
 `;
 
 snapshot[`cli - import_map - "molt deno.json --write" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 📦 deno.land/x/deno_graph 0.50.0 => 0.69.7
 📦 node-emoji 2.0.0 => 2.1.3
@@ -395,12 +395,12 @@ snapshot[`cli - import_map - "molt deno.json --write" 2`] = `
 `;
 
 snapshot[`cli - import_map - "molt deno.json --commit" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 📦 deno.land/x/deno_graph 0.50.0 => 0.69.7
 📦 node-emoji 2.0.0 => 2.1.3
 
-📝 bump @luca/flag from 1.0.0 to 1.1.0
+📝 bump @luca/flag from 1.0.0 to 1.0.1
 📝 bump deno.land/std from 0.200.0 to 0.218.2
 📝 bump deno.land/x/deno_graph from 0.50.0 to 0.69.7
 📝 bump node-emoji from 2.0.0 to 2.1.3
@@ -413,7 +413,7 @@ snapshot[`cli - import_map - "molt deno.json --commit" 2`] = `
 `;
 
 snapshot[`cli - jsonc - "molt deno.jsonc" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 📦 deno.land/x/deno_graph 0.50.0 => 0.69.7
 📦 node-emoji 2.0.0 => 2.1.3
@@ -426,7 +426,7 @@ snapshot[`cli - jsonc - "molt deno.jsonc" 2`] = `
 `;
 
 snapshot[`cli - jsonc - "molt deno.jsonc --write" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 📦 deno.land/x/deno_graph 0.50.0 => 0.69.7
 📦 node-emoji 2.0.0 => 2.1.3
@@ -441,12 +441,12 @@ snapshot[`cli - jsonc - "molt deno.jsonc --write" 2`] = `
 `;
 
 snapshot[`cli - jsonc - "molt deno.jsonc --commit" 1`] = `
-"📦 @luca/flag 1.0.0 => 1.1.0
+"📦 @luca/flag 1.0.0 => 1.0.1
 📦 deno.land/std 0.200.0 => 0.218.2
 📦 deno.land/x/deno_graph 0.50.0 => 0.69.7
 📦 node-emoji 2.0.0 => 2.1.3
 
-📝 bump @luca/flag from 1.0.0 to 1.1.0
+📝 bump @luca/flag from 1.0.0 to 1.0.1
 📝 bump deno.land/std from 0.200.0 to 0.218.2
 📝 bump deno.land/x/deno_graph from 0.50.0 to 0.69.7
 📝 bump node-emoji from 2.0.0 to 2.1.3
@@ -462,7 +462,7 @@ snapshot[`cli - lockfile - "molt deno.json --unstable-lock not_exist.lock" 1`] =
 
 snapshot[`cli - lockfile - "molt deno.json --unstable-lock not_exist.lock" 2`] = `
 "Checking for updates
-Error: Failed to parse lockfile: not_exist.lock
+Error: No such file or directory (os error 2): readfile 'not_exist.lock'
 "
 `;
 

--- a/test/snapshots/file_test.ts.snap
+++ b/test/snapshots/file_test.ts.snap
@@ -123,7 +123,8 @@ snapshot[`write - lockfile_not_importable/mod.ts 2`] = `
   "remote": {
     "https://deno.land/std@0.218.0/version.ts": "cfb73e2f2b628978b2b70585b941c5ef5ccbf1dc06e76967206115c74ecfce49"
   }
-}',
+}
+',
 ]
 `;
 
@@ -1017,7 +1018,8 @@ snapshot[`write - lockfile/deno.json 2`] = `
       "npm:hono@^3"
     ]
   }
-}',
+}
+',
 ]
 `;
 
@@ -1170,7 +1172,8 @@ snapshot[`write - lockfile/mod.ts 2`] = `
       "npm:hono@^3"
     ]
   }
-}',
+}
+',
 ]
 `;
 


### PR DESCRIPTION
- **test(lib/file): check EOL at the end of file**
- **fix: add EOL at the end of updated lock file**
- **test(cli): stub latest version of `jsr:@std/`**
- **test(cli): update snapshot**
