### PR TITLE
Add `--global` option for installing molt

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ supposed to cover most of the use cases.
 The molt CLI can be installed globally with the following command, for example:
 
 ```sh
-deno install --allow-env --allow-read --allow-write --allow-net --allow-run=git,deno\
+deno install --global --allow-env --allow-read --allow-write --allow-net --allow-run=git,deno\
 --name molt jsr:@molt/cli
 ```
 


### PR DESCRIPTION
Now the command shows the warning like this:

```
⚠️ `deno install` behavior will change in Deno 2. To preserve the current behavior use the `-g` or `--global` flag.
```

Maybe molt should be installed as global.