### PR TITLE
fix(core): filter invalid dependencies

### DIFF
--- a/core/update.ts
+++ b/core/update.ts
@@ -210,9 +210,13 @@ export async function collect(
   const result = reduceCollectResult(
     await Promise.all([
       ...graph.modules.flatMap((mod) =>
-        (mod.dependencies ?? []).map((dependency) =>
-          collectFromDependency(dependency, mod.specifier, _options)
-        )
+        (mod.dependencies ?? [])
+          .filter((dependency) =>
+            (dependency.code?.specifier ?? dependency.type?.specifier) != null
+          )
+          .map((dependency) =>
+            collectFromDependency(dependency, mod.specifier, _options)
+          )
       ),
       ...jsons.map((url) => collectFromImportMap(url, _options)),
     ]),

--- a/core/update.ts
+++ b/core/update.ts
@@ -2,7 +2,11 @@ import { findFileUp, toPath, toUrl } from "@molt/lib/path";
 import { assertExists } from "@std/assert";
 import { partition } from "@std/collections";
 import { exists } from "@std/fs";
-import type { ModuleJson } from "@deno/graph";
+import type {
+  DependencyJson,
+  ModuleJson,
+  ResolvedDependency,
+} from "@deno/graph/types";
 import { createGraphLocally } from "./graph.ts";
 import {
   type ImportMap,
@@ -207,13 +211,30 @@ export async function collect(
     importMap,
     lockFile,
   };
+  const showResolveWarning = (
+    mod: ModuleJson,
+    errorDependency: ErrorResolvedDependency,
+  ) => {
+    const { error, span: { start } } = errorDependency;
+    console.warn(
+      `Failed to resolve dependency at ${mod.specifier}:${start.line}:${start.character}: ${error}`,
+    );
+  };
   const result = reduceCollectResult(
     await Promise.all([
       ...graph.modules.flatMap((mod) =>
         (mod.dependencies ?? [])
-          .filter((dependency) =>
-            (dependency.code?.specifier ?? dependency.type?.specifier) != null
-          )
+          .filter((dependency) => {
+            if (isErrorResolvdDependency(dependency.code)) {
+              showResolveWarning(mod, dependency.code);
+              return false;
+            }
+            if (isErrorResolvdDependency(dependency.type)) {
+              showResolveWarning(mod, dependency.type);
+              return false;
+            }
+            return true;
+          })
           .map((dependency) =>
             collectFromDependency(dependency, mod.specifier, _options)
           )
@@ -232,8 +253,6 @@ export async function collect(
 // Inner functions and types
 //
 //----------------------------------
-
-type DependencyJson = NonNullable<ModuleJson["dependencies"]>[number];
 
 interface CollectInnerOptions
   extends Omit<CollectOptions, "importMap" | "lockFile"> {
@@ -433,4 +452,14 @@ function normalizeWithUpdated(
     ...updated,
     version: undefined,
   };
+}
+
+type ErrorResolvedDependency = ResolvedDependency & {
+  error: NonNullable<ResolvedDependency["error"]>;
+};
+
+function isErrorResolvdDependency(
+  x: ResolvedDependency | undefined,
+): x is ErrorResolvedDependency {
+  return x?.error != null;
 }


### PR DESCRIPTION
An assertion error occurs if `graph.modules[].dependencies[]` has an error data like following:

```
error: Uncaught (in promise) AssertionError: Expected actual: "undefined" to not be null or undefined.
    at collectFromDependency (file:///work/deno/molt/core/update.ts:260:13)
    at file:///work/deno/molt/core/update.ts:214:16
    ...
```

```json
{
  "specifier": "@std/collections/filter-keys",
  "code": {
    "error": "JavaScript resolve threw.",
    "span": {
      "start": {"line": 60, "character": 42},
      "end": {"line": 60, "character": 72}
    }
  },
  "isDynamic": true
}
```

I don't know if it's okay to simply filter. Now it works for me.