### PR TITLE
ci: remove CODECOV_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
   test:
     name: Test
     uses: hasundue/actions/.github/workflows/test-deno.yml@main
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       task: test:unit
 


### PR DESCRIPTION
Because it is unnecessary when we use Codecov GitHub App
