### PR TITLE
fix(core): handle identical dependencies correctly

### DIFF
--- a/cli/cli_test.ts
+++ b/cli/cli_test.ts
@@ -60,6 +60,9 @@ molt("mod.ts --no-resolve", { dir: "multiple_modules" });
 molt("mod.ts", { dir: "jsr_with_path_in_import_map" });
 molt("deno.json", { dir: "jsr_with_path_in_import_map" });
 
+// identical dependencies with and without a range specifier
+molt("deno.json", { dir: "import_map_duplicated_imports" });
+
 //-----------------------
 // Test implementation
 //-----------------------

--- a/cli/deno.json
+++ b/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@molt/cli",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "exports": {
     ".": "./main.ts"
   },
@@ -21,7 +21,7 @@
     "@core/unknownutil": "jsr:@core/unknownutil@^3.18.0",
     "@david/dax": "jsr:@david/dax@^0.40.0",
     "@molt/lib": "jsr:@molt/lib@^0.18.0",
-    "@molt/core": "jsr:@molt/core@^0.18.3",
+    "@molt/core": "jsr:@molt/core@^0.18.4",
     "@molt/integration": "jsr:@molt/integration@^0.18.0",
     "@std/assert": "jsr:@std/assert@^0.222.1",
     "@std/collections": "jsr:@std/collections@^0.222.1",

--- a/core/deno.json
+++ b/core/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@molt/core",
-  "version": "0.18.3",
+  "version": "0.18.4",
   "exports": {
     ".": "./mod.ts"
   },

--- a/core/dependency.ts
+++ b/core/dependency.ts
@@ -166,6 +166,13 @@ export async function resolveLatestVersion(
   dependency: Dependency,
   options?: { cache?: boolean },
 ): Promise<UpdatedDependency | undefined> {
+  const constraint = dependency.version
+    ? SemVer.tryParseRange(dependency.version)
+    : undefined;
+  // Do not update inequality ranges.
+  if (constraint && constraint.flat().length > 1) {
+    return;
+  }
   using cache = options?.cache
     ? new LatestVersionCache(dependency.name)
     : undefined;
@@ -175,13 +182,6 @@ export async function resolveLatestVersion(
   }
   if (cached === null) {
     // The dependency is already found to be up to date or unable to resolve.
-    return;
-  }
-  const constraint = dependency.version
-    ? SemVer.tryParseRange(dependency.version)
-    : undefined;
-  // Do not update inequality ranges.
-  if (constraint && constraint.flat().length > 1) {
     return;
   }
   const result = await _resolveLatestVersion(dependency);

--- a/core/import_map_test.ts
+++ b/core/import_map_test.ts
@@ -121,6 +121,23 @@ describe("resolve()", () => {
     );
   });
 
+  it("resolve a jsr specifier with a caret", async () => {
+    const dir = "../test/cases/import_map_duplicated_imports";
+    const importMap = await readFromJson(
+      new URL(`${dir}/deno.json`, import.meta.url),
+    );
+    assertExists(importMap);
+    const referrer = new URL(`${dir}/mod.ts`, import.meta.url);
+    assertEquals(
+      importMap.resolve("@std/testing", referrer),
+      {
+        resolved: "jsr:@std/testing@^0.210.0",
+        key: "@std/testing",
+        value: "jsr:@std/testing@^0.210.0",
+      },
+    );
+  });
+
   it("resolve a jsr specifier with path", async () => {
     const dir = "../test/cases/jsr_with_path_in_import_map";
     const importMap = await readFromJson(

--- a/test/cases/import_map_duplicated_imports/deno.json
+++ b/test/cases/import_map_duplicated_imports/deno.json
@@ -1,0 +1,6 @@
+{
+  "imports": {
+    "@std/testing": "jsr:@std/testing@^0.210.0",
+    "@std/testing/bdd": "jsr:@std/testing@0.210.0/bdd"
+  }
+}

--- a/test/cases/import_map_duplicated_imports/mod.ts
+++ b/test/cases/import_map_duplicated_imports/mod.ts
@@ -1,0 +1,1 @@
+import { describe } from "@std/testing/bdd";

--- a/test/snapshots/cli_test.ts.snap
+++ b/test/snapshots/cli_test.ts.snap
@@ -65,7 +65,7 @@ Options:
 snapshot[`cli - "molt --help" 2`] = `""`;
 
 snapshot[`cli - "molt --version" 1`] = `
-"0.18.3
+"0.18.4
 "
 `;
 
@@ -451,6 +451,16 @@ snapshot[`cli - jsr_with_path_in_import_map - "molt deno.json" 1`] = `
 `;
 
 snapshot[`cli - jsr_with_path_in_import_map - "molt deno.json" 2`] = `
+"Checking for updates
+"
+`;
+
+snapshot[`cli - import_map_duplicated_imports - "molt deno.json" 1`] = `
+"📦 @std/testing 0.210.0 => 0.218.2
+"
+`;
+
+snapshot[`cli - import_map_duplicated_imports - "molt deno.json" 2`] = `
 "Checking for updates
 "
 `;

--- a/test/snapshots/file_test.ts.snap
+++ b/test/snapshots/file_test.ts.snap
@@ -758,6 +758,103 @@ snapshot[`write - import_map/mod.ts 2`] = `
 ]
 `;
 
+snapshot[`write - import_map_duplicated_imports/deno.json 1`] = `
+[
+  {
+    dependencies: [
+      {
+        code: {
+          span: undefined,
+          specifier: "jsr:@std/testing@0.210.0/bdd",
+        },
+        from: {
+          name: "@std/testing",
+          path: "/bdd",
+          protocol: "jsr:",
+          version: "0.210.0",
+        },
+        map: {
+          key: "@std/testing/bdd",
+          resolved: "jsr:@std/testing@0.210.0/bdd",
+        },
+        to: {
+          name: "@std/testing",
+          path: "/bdd",
+          protocol: "jsr:",
+          version: "123.456.789",
+        },
+      },
+    ],
+    kind: "import_map",
+  },
+]
+`;
+
+snapshot[`write - import_map_duplicated_imports/deno.json 2`] = `
+[
+  '{
+  "imports": {
+    "@std/testing": "jsr:@std/testing@^0.210.0",
+    "@std/testing/bdd": "jsr:@std/testing@123.456.789/bdd"
+  }
+}
+',
+]
+`;
+
+snapshot[`write - import_map_duplicated_imports/mod.ts 1`] = `
+[
+  {
+    dependencies: [
+      {
+        code: {
+          span: {
+            end: {
+              character: 43,
+              line: 0,
+            },
+            start: {
+              character: 25,
+              line: 0,
+            },
+          },
+          specifier: "@std/testing/bdd",
+        },
+        from: {
+          name: "@std/testing",
+          path: "/bdd",
+          protocol: "jsr:",
+          version: "0.210.0",
+        },
+        map: {
+          key: "@std/testing/bdd",
+          resolved: "jsr:@std/testing@0.210.0/bdd",
+        },
+        to: {
+          name: "@std/testing",
+          path: "/bdd",
+          protocol: "jsr:",
+          version: "123.456.789",
+        },
+      },
+    ],
+    kind: "import_map",
+  },
+]
+`;
+
+snapshot[`write - import_map_duplicated_imports/mod.ts 2`] = `
+[
+  '{
+  "imports": {
+    "@std/testing": "jsr:@std/testing@^0.210.0",
+    "@std/testing/bdd": "jsr:@std/testing@123.456.789/bdd"
+  }
+}
+',
+]
+`;
+
 snapshot[`write - npm.ts 1`] = `
 [
   {

--- a/test/snapshots/update_test.ts.snap
+++ b/test/snapshots/update_test.ts.snap
@@ -541,6 +541,61 @@ snapshot[`collect - import_map - mod.ts 1`] = `
 ]
 `;
 
+snapshot[`collect - import_map_duplicated_imports - deno.json 1`] = `
+[
+  {
+    code: {
+      span: undefined,
+      specifier: "jsr:@std/testing@0.210.0/bdd",
+    },
+    from: {
+      name: "@std/testing",
+      path: "/bdd",
+      protocol: "jsr:",
+      version: "0.210.0",
+    },
+    to: {
+      name: "@std/testing",
+      path: "/bdd",
+      protocol: "jsr:",
+      version: "123.456.789",
+    },
+  },
+]
+`;
+
+snapshot[`collect - import_map_duplicated_imports - mod.ts 1`] = `
+[
+  {
+    code: {
+      span: {
+        end: {
+          character: 43,
+          line: 0,
+        },
+        start: {
+          character: 25,
+          line: 0,
+        },
+      },
+      specifier: "@std/testing/bdd",
+    },
+    from: {
+      name: "@std/testing",
+      path: "/bdd",
+      protocol: "jsr:",
+      version: "0.210.0",
+    },
+    to: {
+      name: "@std/testing",
+      path: "/bdd",
+      protocol: "jsr:",
+      version: "123.456.789",
+    },
+  },
+]
+`;
+
 snapshot[`collect - npm.ts 1`] = `
 [
   {


### PR DESCRIPTION
This fixes a problematic behavior when identical dependencies with and without range specifiers, such as ^, ~, or x. For example, if we have `jsr:@std/testing@^0.210.0` and `jsr:@std/testing@0.210.0/bdd` at the same time, both are updated to the latest version, or neither is updated, which should not happen.